### PR TITLE
Fix PluralFormat JSON name

### DIFF
--- a/Lokalise.Api/Collections/Files/Requests/DownloadFileRequest.cs
+++ b/Lokalise.Api/Collections/Files/Requests/DownloadFileRequest.cs
@@ -113,7 +113,7 @@ namespace Lokalise.Api.Collections.Files.Requests
         [JsonPropertyName("disable_references")]
         public bool? DisableReferences { get; set; }
 
-        [JsonPropertyName("plural_formats")]
+        [JsonPropertyName("plural_format")]
         public string? PluralFormat { get; set; }
 
         [JsonPropertyName("placeholder_format")]


### PR DESCRIPTION
First of all, thanks for this handy library, it's very neatly formed and joy to use!

I was experimenting with downloads and found that a wrong parameter name is being sent for plural format making the response always use default format.

From [the API spec:](https://app.lokalise.com/api2docs/curl/#transition-download-files-post):

| Parameter | Type | Description |
| --- |--- |--- |
| `plural_format` | `string` | Override the default plural format for the file type. Allowed values are `json_string`, `icu`, `array`, `generic`, `symfony`, `i18next`. See Plurals and placeholders for more information about plural support for specific file formats. |