### PR TITLE
Switch to using PackageLicenseExpression

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    
+    - uses: actions/checkout@v4
+
     - name: Get Build Version
       run: |
         Import-Module .\build\GetBuildVersion.psm1
@@ -31,22 +31,11 @@ jobs:
         echo "BUILD_VERSION=$version" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
       shell: pwsh
 
-    - name: Setup NuGet
-      uses: NuGet/setup-nuget@v1.0.5
-
-    - name: Restore dependencies
-      run: nuget restore $SOLUTION
-
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
-
     - name: Restore dependencies
       run: dotnet restore
 
     - name: Build
-      run: dotnet build $SOLUTION --configuration $BUILD_CONFIG -p:Version=$BUILD_VERSION --no-restore
+      run: dotnet build $SOLUTION --configuration $BUILD_CONFIG -p:ContinuousIntegrationBuild=True -p:Version=$BUILD_VERSION --no-restore
 
     - name: Publish
       if: startsWith(github.ref, 'refs/heads/release')

--- a/.gitignore
+++ b/.gitignore
@@ -350,3 +350,5 @@ MigrationBackup/
 .ionide/
 
 Lokalise.Api.LocalTests/appconfig.json
+
+.idea/

--- a/Lokalise.Api/Lokalise.Api.csproj
+++ b/Lokalise.Api/Lokalise.Api.csproj
@@ -7,26 +7,16 @@
     <Authors>Andy Mepham</Authors>
     <Version>1.0.0-alpha.1</Version>
     <Description>Lokalise SDK for .NET projects, based on the V2 API specification</Description>
-    <PackageProjectUrl></PackageProjectUrl>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageProjectUrl>https://github.com/AndyMeps/net-lokalise-api</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/AndyMeps/net-lokalise-api</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
-	  <None Include="LICENSE" Pack="true" PackagePath="" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="5.0.1" />
+    <None Include="LICENSE" Pack="true" PackagePath="" />
+    <None Include="..\README.md" Pack="True" PackagePath="\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
NuGet.org will then be able to show the correct license info and also automatic license checkers/validator will work properly. Also updates GH Actions workflow definition to do a deterministic build and cleaned up against the latest runners which don't need installations. Explicit System.Text.Json reference should also not be needed when you target net6.0.

Have you considered to make the big 1.0 release yet - this is working great! 🙂 