### PR TITLE
Add Download files (Async) to API

### DIFF
--- a/Lokalise.Api.LocalTests/ProcessTests.cs
+++ b/Lokalise.Api.LocalTests/ProcessTests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Text;
+using System.Threading.Tasks;
+using Lokalise.Api.Models;
+using Xunit;
+
+namespace Lokalise.Api.LocalTests;
+
+public class ProcessTests : LocalTests
+{
+    [Fact]
+    public async Task RetrieveProcess_JsonStringShouldRetrieve()
+    {
+        // Arrange
+        var testProject = await EnsureTestProjectAsync();
+
+        Assert.NotNull(testProject.ProjectId);
+
+        var uploadResult = await LokaliseClient.Files.UploadAsync(testProject.ProjectId!, Convert.ToBase64String(Encoding.UTF8.GetBytes("{ \"key\": \"value\" }")), "test-file.json", "en");
+
+        Assert.NotNull(uploadResult);
+        Assert.Equal(uploadResult!.ProjectId, testProject.ProjectId);
+        Assert.NotNull(uploadResult.Location);
+        Assert.NotNull(uploadResult.Process);
+
+        await Task.Delay(TimeSpan.FromSeconds(5));
+
+        // Act
+        var exportProcess = await LokaliseClient.Files.StartExportAsync(testProject.ProjectId!, "json");
+        ProcessInformation? processInformation = null;
+        const int maxTryCount = 5;
+        var tryCount = 0;
+        while (tryCount < maxTryCount || processInformation!.Process!.Status != Process.StatusFinished)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(5));
+            processInformation = await LokaliseClient.Processes.RetrieveProcessAsync(testProject.ProjectId!, exportProcess!.ProcessId!);
+            tryCount++;
+        }
+                
+        // Assert
+        Assert.NotNull(processInformation);
+        Assert.Equal(testProject.ProjectId, processInformation.ProjectId);
+        Assert.NotNull(processInformation.Process);
+        Assert.Equal("file-import", processInformation.Process!.Type);
+        Assert.NotNull(processInformation.Process.Details?.DownloadUrl);
+    }
+}

--- a/Lokalise.Api/Collections/Files/FilesCollection.cs
+++ b/Lokalise.Api/Collections/Files/FilesCollection.cs
@@ -55,6 +55,19 @@ namespace Lokalise.Api.Collections.Files
 
             return result;
         }
+        
+        /// <inheritdoc />
+        public async Task<ExportProcess?> StartExportAsync(string projectId, string format, Action<DownloadFileConfiguration>? options = null)
+        {
+            var cfg = new DownloadFileConfiguration();
+            options?.Invoke(cfg);
+
+            var result = await PostAsync<DownloadFileRequest, ExportProcess>(
+                $"{FilesUri(projectId, cfg.Branch)}/async-download",
+                new DownloadFileRequest(format, cfg));
+
+            return result;
+        }
 
         private async Task<UploadedFile?> UploadInternalAsync(string projectId, string data, string filename, string langIso, Action<UploadFileConfiguration>? options = null)
         {

--- a/Lokalise.Api/Collections/Files/IFilesCollection.cs
+++ b/Lokalise.Api/Collections/Files/IFilesCollection.cs
@@ -32,7 +32,14 @@ namespace Lokalise.Api.Collections.Files
         /// <para>Exports project files as a .zip bundle. Generated bundle will be uploaded to an Amazon S3 bucket, which will be stored there for 12 months available to download. As the bundle is generated and uploaded you would get a response with the URL to the file. Requires Download files admin right.</para>
         /// <para>There are two ways to group keys by filenames when you are exporting - either all keys to a single file per language or use the previously assigned filenames.</para>
         /// <para>Requires read_files OAuth access scope.</para>
+        /// <para>Please note: Starting June 1st, 2025, this endpoint will be limited to projects with under 10,000 key-language pairs.</para>
         /// </summary>
         public Task<DownloadedFiles?> DownloadAsync(string projectId, string format, Action<DownloadFileConfiguration>? options = null);
+        
+        /// <summary>
+        /// <para>Starts a project export process. The progress of the process can be tracked using the list all processes API endpoint. Once complete, the download URL can be accessed using the Retrieve process API endpoint.</para>
+        /// <para>For general details about the Download endpoint, please refer to the Download files API endpoint.</para>
+        /// </summary>
+        public Task<ExportProcess?> StartExportAsync(string projectId, string format, Action<DownloadFileConfiguration>? options = null);
     }
 }

--- a/Lokalise.Api/Collections/Processes/IProcessesCollection.cs
+++ b/Lokalise.Api/Collections/Processes/IProcessesCollection.cs
@@ -1,0 +1,17 @@
+﻿using System.Threading.Tasks;
+using Lokalise.Api.Models;
+
+namespace Lokalise.Api.Collections.Processes
+{
+    public interface IProcessesCollection
+    {
+        /// <summary>
+        /// <para>Retrieves a Queued process object with an additional details field containing information for a specific process type.</para>
+        /// <para>Requires read_background_processes OAuth access scope.</para>
+        /// </summary>
+        /// <param name="projectId">A unique project identifier</param>
+        /// <param name="processId">A unique process identifier.</param>
+        /// <returns></returns>
+        public Task<ProcessInformation?> RetrieveProcessAsync(string projectId, string processId);
+    }
+}

--- a/Lokalise.Api/Collections/Processes/ProcessesCollection.cs
+++ b/Lokalise.Api/Collections/Processes/ProcessesCollection.cs
@@ -1,0 +1,26 @@
+﻿using Lokalise.Api.Models;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Lokalise.Api.Collections.Processes
+{
+    internal class ProcessesCollection : BaseCollection, IProcessesCollection
+    {
+        internal ProcessesCollection(
+            HttpClient httpClient,
+            JsonSerializerOptions jsonSerializerOptions)
+            : base(httpClient, jsonSerializerOptions)
+        {
+        }
+
+        /// <inheritdoc />
+        public async Task<ProcessInformation?> RetrieveProcessAsync(string projectId, string processId)
+        {
+            var result = await GetAsync<ProcessInformation>($"{ProcessesUri(projectId)}/{processId}");
+            return result;
+        }
+        
+        private string ProcessesUri(string projectId) => $"projects/{projectId}/processes";
+    }
+}

--- a/Lokalise.Api/ILokaliseClient.cs
+++ b/Lokalise.Api/ILokaliseClient.cs
@@ -3,6 +3,7 @@ using Lokalise.Api.Collections.Comments;
 using Lokalise.Api.Collections.Contributors;
 using Lokalise.Api.Collections.Files;
 using Lokalise.Api.Collections.Keys;
+using Lokalise.Api.Collections.Processes;
 using Lokalise.Api.Collections.Projects;
 
 namespace Lokalise.Api
@@ -13,6 +14,7 @@ namespace Lokalise.Api
         public ICommentsCollection Comments { get; }
         public IContributorsCollection Contributors { get; }
         public IProjectsCollection Projects { get; }
+        public IProcessesCollection Processes { get; }
         public IFilesCollection Files { get; }
         public IKeysCollection Keys { get; }
     }

--- a/Lokalise.Api/LokaliseClient.cs
+++ b/Lokalise.Api/LokaliseClient.cs
@@ -8,6 +8,7 @@ using System;
 using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Lokalise.Api.Collections.Processes;
 
 namespace Lokalise.Api
 {
@@ -20,6 +21,7 @@ namespace Lokalise.Api
 
         private IFilesCollection? _files;
         private IProjectsCollection? _projects;
+        private IProcessesCollection? _processes;
         private IBranchesCollection? _branches;
         private ICommentsCollection? _comments;
         private IContributorsCollection? _contributors;
@@ -44,6 +46,8 @@ namespace Lokalise.Api
         public IFilesCollection Files => _files ??= new FilesCollection(_httpClient, _jsonSerializerOptions);
 
         public IProjectsCollection Projects => _projects ??= new ProjectsCollection(_httpClient, _jsonSerializerOptions);
+        
+        public IProcessesCollection Processes => _processes ??= new ProcessesCollection(_httpClient, _jsonSerializerOptions);
 
         public IBranchesCollection Branches => _branches ??= new BranchesCollection(_httpClient, _jsonSerializerOptions);
 

--- a/Lokalise.Api/Models/ExportProcess.cs
+++ b/Lokalise.Api/Models/ExportProcess.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace Lokalise.Api.Models;
+
+public class ExportProcess
+{
+    [JsonPropertyName("process_id")]
+    public string? ProcessId { get; set; }
+}

--- a/Lokalise.Api/Models/Process.cs
+++ b/Lokalise.Api/Models/Process.cs
@@ -1,0 +1,51 @@
+using System.Text.Json.Serialization;
+
+namespace Lokalise.Api.Models;
+
+public class Process
+{
+    public const string StatusQueued = "queued";
+    public const string StatusPreProcessing = "pre_processing";
+    public const string StatusRunning = "running";
+    public const string StatusPostProcessing = "post_processing";
+    public const string StatusCancelled = "cancelled";
+    public const string StatusFinished = "finished";
+    public const string StatusFailed = "failed";
+    
+    [JsonPropertyName("process_id")]
+    public string? ProcessId { get; set; }
+    
+    /// <summary>
+    /// The type of the process. Can be file-import, sketch-import or bulk-apply-tm.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+    
+    /// <summary>
+    /// Current status of the process.
+    /// Can be queued, pre_processing, running, post_processing, cancelled, finished or failed.
+    /// </summary>
+    [JsonPropertyName("status")]
+    public string? Status { get; set; }
+    
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
+    
+    [JsonPropertyName("created_by")]
+    public int? CreatedBy { get; set; }    
+    
+    [JsonPropertyName("created_by_email")]
+    public string? CreatedByEmail { get; set; }
+    
+    [JsonPropertyName("created_at")]
+    public string? CreatedAt { get; set; }
+    
+    [JsonPropertyName("created_at_timestamp")]
+    public int? CreatedAtTimestamp { get; set; }
+
+    /// <summary>
+    /// Contains information for a specific process type.
+    /// </summary>
+    [JsonPropertyName("details")]
+    public ProcessDetails? Details { get; set; }
+}

--- a/Lokalise.Api/Models/ProcessDetails.cs
+++ b/Lokalise.Api/Models/ProcessDetails.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace Lokalise.Api.Models;
+
+public class ProcessDetails
+{
+    [JsonPropertyName("download_url")]
+    public string? DownloadUrl { get; set; }
+    [JsonPropertyName("total_number_of_keys")]
+    public int? TotalNumberOfKeys { get; set; }
+    [JsonPropertyName("file_size_kb")]
+    public int? FileSizeKb { get; set; }
+}

--- a/Lokalise.Api/Models/ProcessInformation.cs
+++ b/Lokalise.Api/Models/ProcessInformation.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Lokalise.Api.Models;
+
+public class ProcessInformation
+{
+    [JsonPropertyName("project_id")]
+    public string? ProjectId { get; set; }
+    
+    [JsonPropertyName("process")]
+    public Process? Process { get; set; }
+}


### PR DESCRIPTION
A new method for large file downloads that prevents timeouts and failures. Lokalise will limit the existing File Download endpoint to 3 seconds response time and longer requests will be blocked, starting June 1st, 2025 (https://developers.lokalise.com/reference/download-files).

Using the new API method requires also another method for retrieving the process status.

New methods added:
* https://developers.lokalise.com/reference/download-files-async
* https://developers.lokalise.com/reference/retrieve-a-process